### PR TITLE
Update Slick buildRows.

### DIFF
--- a/_demo/index.html
+++ b/_demo/index.html
@@ -13,7 +13,7 @@
     </head>
     <body>
         <main>
-            <section id="features" class="blue">                
+            <section id="features" class="blue">
 			    <div class="content">
 				    <h2>Features</h2>
 				    <ul class="features">
@@ -28,7 +28,7 @@
 					    <li>Autoplay, dots, arrows, callbacks, etc...</li>
 				    </ul>
 				    <hr id="demos"/>
-				    <h2>Single Item</h2>
+            <h2>Single Item</h2>
 				    <div class="slider single-item">
 					    <div><h3>1</h3></div>
 					    <div><h3>2</h3></div>
@@ -39,6 +39,26 @@
 				    </div>
 				    <pre><code class="language-javascript">
 $('.single-item').slick();
+				    </code></pre>
+				    <hr/>
+            <h2>Rows Item</h2>
+				    <div class="slider rows-item">
+					    <div><h3>1</h3></div>
+					    <div><h3>2</h3></div>
+					    <div><h3>3</h3></div>
+					    <div><h3>4</h3></div>
+					    <div><h3>5</h3></div>
+					    <div><h3>6</h3></div>
+				    </div>
+				    <pre><code class="language-javascript">
+              $('.rows-item').slick({
+                    dots: true,
+                    infinite: true,
+                    speed: 500,
+                    slidesToShow: 1,
+                    slidesToScroll: 1,
+                    rows: 2
+                });
 				    </code></pre>
 				    <hr/>
 				    <h2>Multiple Items</h2>

--- a/_demo/scripts.js
+++ b/_demo/scripts.js
@@ -6,6 +6,14 @@ $(document).ready(function() {
         slidesToShow: 1,
         slidesToScroll: 1
     });
+    $('.rows-item').slick({
+        dots: true,
+        infinite: true,
+        speed: 500,
+        slidesToShow: 1,
+        slidesToScroll: 1,
+        rows: 2
+    });
     $('.multiple-items').slick({
         dots: true,
         infinite: true,

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -581,9 +581,7 @@ Issues: http://github.com/kenwheeler/slick/issues
 		var _ = this, a, b, c, newSlides, numOfSlides, originalSlides, slidesPerSection;
 
 		newSlides = document.createDocumentFragment();
-		originalSlides = _.$slider.get();
-		originalSlides = originalSlides[0].children;
-		originalSlides = [].slice.call(originalSlides);
+		originalSlides = [].slice.call(_.$slider.get(0).children);
 
 		if(_.options.rows > 1) {
 			slidesPerSection = _.options.slidesPerRow * _.options.rows;

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -578,43 +578,41 @@ Issues: http://github.com/kenwheeler/slick/issues
 
 	Slick.prototype.buildRows = function() {
 
-		var _ = this, a, b, c, newSlides, numOfSlides, originalSlides,slidesPerSection;
+		var _ = this, a, b, c, newSlides, numOfSlides, originalSlides, slidesPerSection;
 
 		newSlides = document.createDocumentFragment();
-		originalSlides = _.$slider.children();
+		originalSlides = _.$slider.get();
+		originalSlides = originalSlides[0].children;
+		originalSlides = [].slice.call(originalSlides);
 
 		if(_.options.rows > 1) {
-
 			slidesPerSection = _.options.slidesPerRow * _.options.rows;
-			numOfSlides = Math.ceil(
-				originalSlides.length / slidesPerSection
-			);
-
+			numOfSlides = Math.ceil(originalSlides.length / slidesPerSection);
 			for(a = 0; a < numOfSlides; a++){
 				var slide = document.createElement('div');
 				for(b = 0; b < _.options.rows; b++) {
 					var row = document.createElement('div');
 					for(c = 0; c < _.options.slidesPerRow; c++) {
 						var target = (a * slidesPerSection + ((b * _.options.slidesPerRow) + c));
-						if (originalSlides.get(target)) {
-							row.appendChild(originalSlides.get(target));
+						if (originalSlides[target]) {
+							row.appendChild(originalSlides[target]);
 						}
 					}
 					slide.appendChild(row);
 				}
 				newSlides.appendChild(slide);
 			}
+			var vanilla$slider = _.$slider.get();
+			vanilla$slider[0].innerHTML = '';
+			vanilla$slider[0].appendChild(newSlides);
 
-			_.$slider.empty().append(newSlides);
-			_.$slider.children().children().children()
-				.css({
-					'width':(100 / _.options.slidesPerRow) + '%',
-					'display': 'inline-block'
-				});
-
+			[].forEach.call(originalSlides[0], function(children) {
+				children.style.width = (100 / _.options.slidesPerRow) + '%';
+				children.style.display = 'inline-block';
+			});
 		}
 
-	};
+  };
 
 	Slick.prototype.checkResponsive = function(initial, forceUpdate) {
 

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -578,43 +578,42 @@ Issues: http://github.com/kenwheeler/slick/issues
 
 	Slick.prototype.buildRows = function() {
 
-		var _ = this, a, b, c, newSlides, numOfSlides, originalSlides,slidesPerSection;
+		var _ = this, a, b, c, newSlides, numOfSlides, originalSlides, slidesPerSection;
 
 		newSlides = document.createDocumentFragment();
-		originalSlides = _.$slider.children();
+		originalSlides = _.$slider.get();
+		originalSlides = originalSlides[0].children;
+		originalSlides = [].slice.call(originalSlides);
 
 		if(_.options.rows > 1) {
-
 			slidesPerSection = _.options.slidesPerRow * _.options.rows;
-			numOfSlides = Math.ceil(
-				originalSlides.length / slidesPerSection
-			);
-
+			numOfSlides = Math.ceil(originalSlides.length / slidesPerSection);
 			for(a = 0; a < numOfSlides; a++){
 				var slide = document.createElement('div');
 				for(b = 0; b < _.options.rows; b++) {
 					var row = document.createElement('div');
 					for(c = 0; c < _.options.slidesPerRow; c++) {
 						var target = (a * slidesPerSection + ((b * _.options.slidesPerRow) + c));
-						if (originalSlides.get(target)) {
-							row.appendChild(originalSlides.get(target));
+						if (originalSlides[target]) {
+							console.log(typeof originalSlides);
+							row.appendChild(originalSlides[target]);
 						}
 					}
 					slide.appendChild(row);
 				}
 				newSlides.appendChild(slide);
 			}
+			var vanilla$slider = _.$slider.get();
+			vanilla$slider[0].innerHTML = '';
+			vanilla$slider[0].appendChild(newSlides);
 
-			_.$slider.empty().append(newSlides);
-			_.$slider.children().children().children()
-				.css({
-					'width':(100 / _.options.slidesPerRow) + '%',
-					'display': 'inline-block'
-				});
-
+			[].forEach.call(originalSlides[0], function(children) {
+				children.style.width = (100 / _.options.slidesPerRow) + '%';
+				children.style.display = 'inline-block';
+			});
 		}
 
-	};
+  };
 
 	Slick.prototype.checkResponsive = function(initial, forceUpdate) {
 


### PR DESCRIPTION
Update Slick buildRows function in order to be jQuery free.

Add new slider example in index.html and script.js
in order to display slider with rows option on demo page.
